### PR TITLE
Mvvm Improvements

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <runningDeviceTargetSelectedWithDropDown>
+      <Target>
+        <type value="RUNNING_DEVICE_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="SERIAL_NUMBER" />
+            <value value="NQX4C20612001817" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2023-02-06T17:11:14.158904200Z" />
+  </component>
+</project>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -11,7 +11,7 @@ Implementation of the omdb API for android utilizing clean android architecture 
 
 ## Bugs
 
-- moving back from Movie details page needs to be like the previous button
+ - no inherent bugs
 
 ## Improvements that will be made on the application :-
 

--- a/app/src/main/java/com/example/liebmovies/dependencyinjection/DispatchersModule.kt
+++ b/app/src/main/java/com/example/liebmovies/dependencyinjection/DispatchersModule.kt
@@ -1,0 +1,33 @@
+package com.example.liebmovies.dependencyinjection
+import dagger.Module
+import dagger.Provides
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Qualifier
+    @Module
+    object DispatchersModule {
+        @DefaultDispatcher
+        @Provides
+        fun providesDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
+
+        @IoDispatcher
+        @Provides
+        fun providesIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
+
+        @MainDispatcher
+        @Provides
+        fun providesMainDispatcher(): CoroutineDispatcher = Dispatchers.Main
+    }
+
+    @Retention(AnnotationRetention.BINARY)
+    @Qualifier
+    annotation class DefaultDispatcher
+
+    @Retention(AnnotationRetention.BINARY)
+    @Qualifier
+    annotation class IoDispatcher
+
+    @Retention(AnnotationRetention.BINARY)
+    @Qualifier
+    annotation class MainDispatcher
+

--- a/app/src/main/java/com/example/liebmovies/dependencyinjection/RetroModule.kt
+++ b/app/src/main/java/com/example/liebmovies/dependencyinjection/RetroModule.kt
@@ -2,10 +2,13 @@ package com.example.liebmovies.dependencyinjection
 
 import com.example.liebmovies.interfaces.ApiInterface
 import com.example.liebmovies.network.repositories.GetMoviesRepository
+import com.example.liebmovies.network.usecases.GetMovieDetailsUseCase
 import com.example.liebmovies.network.usecases.GetMoviesUseCase
+import com.example.liebmovies.viewmodels.MoviesViewModelFactory
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
 import dagger.Provides
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType

--- a/app/src/main/java/com/example/liebmovies/fragments/MoviesListFragment.kt
+++ b/app/src/main/java/com/example/liebmovies/fragments/MoviesListFragment.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
-import android.text.Editable
-import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -26,7 +24,9 @@ import com.example.liebmovies.commons.ClickedMovieParams
 import com.example.liebmovies.domains.MyMovieDetails
 import com.example.liebmovies.domains.MyMoviesData
 import com.example.liebmovies.viewmodels.MoviesViewModel
+import com.example.liebmovies.viewmodels.MoviesViewModelFactory
 import com.google.android.material.snackbar.Snackbar
+import javax.inject.Inject
 
 
 class MoviesListFragment : Fragment() {
@@ -39,6 +39,9 @@ class MoviesListFragment : Fragment() {
     // This property is only valid between onCreateView and
     // onDestroyView.
     private val binding get() = _binding!!
+
+    @Inject
+    lateinit var getMoviesViewModelFactory: MoviesViewModelFactory
 
     lateinit var moviesViewModel: MoviesViewModel
 
@@ -106,13 +109,11 @@ class MoviesListFragment : Fragment() {
     private fun initViewModel() {
         val errorMessage = getString(R.string.errorMessage)
 
-        moviesViewModel = ViewModelProvider(this)[MoviesViewModel::class.java]
-        (requireActivity() as MoviesActivity).retroComponent.inject(moviesViewModel)
+        (requireActivity() as MoviesActivity).retroComponent.inject(this)
+        moviesViewModel = ViewModelProvider(this, getMoviesViewModelFactory)[MoviesViewModel::class.java]
         _binding?.moviesViewModel = moviesViewModel
         _binding?.lifecycleOwner = this
         // region for movie list
-        moviesViewModel.liveMovieCount.observe(viewLifecycleOwner) { _ ->
-        }
 
         moviesViewModel.liveSearchText.observe(viewLifecycleOwner) { char ->
             recyclerViewAdapter.filter.filter(char)

--- a/app/src/main/java/com/example/liebmovies/interfaces/RetroComponent.kt
+++ b/app/src/main/java/com/example/liebmovies/interfaces/RetroComponent.kt
@@ -1,12 +1,19 @@
 package com.example.liebmovies.interfaces
+import com.example.liebmovies.dependencyinjection.DispatchersModule
 import com.example.liebmovies.dependencyinjection.RetroModule
-import com.example.liebmovies.viewmodels.MoviesViewModel
+import com.example.liebmovies.fragments.MoviesListFragment
+import com.example.liebmovies.viewmodels.MoviesViewModelFactory
 import dagger.Component
 import javax.inject.Singleton
 
 @Singleton
-@Component(modules = [RetroModule::class])
+@Component(
+    modules = [
+        RetroModule::class,
+        DispatchersModule::class
+    ]
+)
 interface RetroComponent {
 
-    fun inject(moviesViewModel: MoviesViewModel)
+    fun inject(moviesListFragment: MoviesListFragment)
 }

--- a/app/src/main/java/com/example/liebmovies/viewmodels/MoviesViewModelFactory.kt
+++ b/app/src/main/java/com/example/liebmovies/viewmodels/MoviesViewModelFactory.kt
@@ -1,0 +1,18 @@
+package com.example.liebmovies.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.liebmovies.dependencyinjection.MainDispatcher
+import com.example.liebmovies.network.usecases.GetMovieDetailsUseCase
+import com.example.liebmovies.network.usecases.GetMoviesUseCase
+import kotlinx.coroutines.CoroutineDispatcher
+import javax.inject.Inject
+
+class MoviesViewModelFactory @Inject constructor (@MainDispatcher val dispatcher: CoroutineDispatcher, val getMoviesUseCase: GetMoviesUseCase,
+                                                  val getMovieDetailsUseCase: GetMovieDetailsUseCase
+): ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            @Suppress("UNCHECKED_CAST")
+            return MoviesViewModel(dispatcher, getMoviesUseCase, getMovieDetailsUseCase) as T
+        }
+}


### PR DESCRIPTION
- Updated the MVVM implementation
  - Added viewModelFactory to Dagger2 , making constructor injection for the vm instead of field injection
  - Injected the Dispatchers instead of hardcoding them
  - Utilized SingleLiveData and LiveData fully to prevent the mutable livedata from restart the

**_Improvments**

* maybe use

```
  val applicationContext: Context
    val firstViewModel: FirstViewModel
````

```
    @Component.Factory
    interface Factory {
        fun create(@BindsInstance applicationContext: Context): AppComponent
    }
````

`private val viewModel: FirstViewModel by injectVmWith { appInjector.firstViewModel }`

in the retroComponent and moviesListFragment to call the retro component from anywhere in the app

* maybe use multi binding